### PR TITLE
Docker build automated with Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM java:openjdk-7-jdk
 
-RUN mkdir /compile
-
 WORKDIR /compile
 
-CMD [ "./compile.sh" ]
+ADD compile.sh /compile/
+ADD rsc/ /compile/rsc
+ADD src/ /compile/src
+
+RUN [ "./compile.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+
+  graphwar:
+    image: graphwar
+    container_name: graphwar
+    build:
+      context: .
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    environment:
+      - DISPLAY=${DISPLAY}
+    command: java -jar graphwar.jar

--- a/makefile
+++ b/makefile
@@ -14,29 +14,6 @@ all:
 	rm -rf GlobalServer
 	rm -rf RoomServer
 
-docker-graphwar:
-
-	## build graphwar inside of a container
-	docker run --rm \
-		-v ${PWD}:/compile \
-		graphwar/build
-
-docker-image:
-
-	## build docker image
-	docker build -t graphwar/build .
-
-run-client:
-
-	## run graphwar on a container
-	docker run --rm \
-		-v ${PWD}:/compile \
-		-v /tmp/.X11-unix:/tmp/.X11-unix \
-		-e DISPLAY=${DISPLAY} \
-		--network host \
-		graphwar/build \
-		java -jar graphwar.jar
-
 clean:
 
 	rm -r bin

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,8 @@ Compile the game using the make command (or on your favorite IDE).
 
 To run the game execute graphwar.jar.
 
+Alternatively, you can try it with Docker Compose: `docker-compose up`
+
 ## Running Local Servers
 
 To run a local server and connect to it you must pass the ip of the local server to graphwar


### PR DESCRIPTION
Replaced Makefile Docker commands in a Docker Compose file. 

Now you can try the project with Docker by running `docker-compose up` instead of `docker-image; make run-client`