### PR TITLE
Fix: makefile error and compile warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-7-jdk
+FROM amazoncorretto:8
 
 RUN mkdir /compile
 

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 all:
 
 	mkdir -p bin
-	javac -Xlint:deprecation -source 1.6 -target 1.6 -d bin/ -sourcepath src/ -classpath bin/ src/Graphwar/*.java src/GraphServer/*.java src/GlobalServer/*.java src/RoomServer/*.java
+	javac -Xlint:deprecation -d bin/ -sourcepath src/ -classpath bin/ src/Graphwar/*.java src/GraphServer/*.java src/GlobalServer/*.java src/RoomServer/*.java
 	cp -r bin/Graphwar Graphwar
 	cp -r bin/GraphServer GraphServer
 	cp -r bin/GlobalServer GlobalServer

--- a/src/Graphwar/GameData.java
+++ b/src/Graphwar/GameData.java
@@ -366,7 +366,7 @@ public class GameData implements Runnable
 	{
 		if(players.size() < Constants.MAX_PLAYERS)
 		{
-			nextPCs.add(new Integer(level));
+			nextPCs.add(level);
 			
 			addPlayer(name);
 		}

--- a/src/Graphwar/GlobalScreen.java
+++ b/src/Graphwar/GlobalScreen.java
@@ -233,7 +233,7 @@ public class GlobalScreen extends JPanel implements ActionListener, StartStopPan
 		showMessage = true;
 		this.message = message;
 		
-		FontMetrics fontMetrics = Toolkit.getDefaultToolkit().getFontMetrics (Constants.NAME_FONT);		
+		FontMetrics fontMetrics = this.getFontMetrics(Constants.NAME_FONT);
 		int messageLength = fontMetrics.stringWidth(message);
 		
 		this.messageX = (Constants.WIDTH - messageLength)/2;

--- a/src/Graphwar/MainMenuScreen.java
+++ b/src/Graphwar/MainMenuScreen.java
@@ -295,7 +295,7 @@ public class MainMenuScreen extends JPanel implements ActionListener
 		showMessage = true;
 		this.message = message;
 		
-		FontMetrics fontMetrics = Toolkit.getDefaultToolkit().getFontMetrics (Constants.NAME_FONT);		
+				FontMetrics fontMetrics = this.getFontMetrics(Constants.NAME_FONT);
 		int messageLength = fontMetrics.stringWidth(message);
 		
 		this.messageX = (Constants.WIDTH - messageLength)/2;


### PR DESCRIPTION
1. Remove -source 1.6 -target 1.6 to fix `error: Source/Target option 6 is no longer supported. Use 7 or later.`
2. Modify the jdk source in Dockerfile from java:openjdk-7-jdk to amazoncorretto:8
3. Modify `src/Graphwar/GameData.java:369` from `new Integer(level)` to `level` to fix src/Graphwar/GameData.java:369: warning: [removal] Integer(int) in Integer has been deprecated and marked for removal nextPCs.add(new Integer(level));
4. Replace `Toolkit.getDefaultToolkit()` with `this` in `GlobalScreen.java:236` and `MainMenuScreen.java:298` to fix warning: [deprecation] getFontMetrics(Font) in Toolkit has been deprecated