### PR TITLE
Fix: 2 bugs about the confusion about local players and computer players:

### DIFF
--- a/src/Graphwar/GameData.java
+++ b/src/Graphwar/GameData.java
@@ -115,6 +115,7 @@ public class GameData implements Runnable
 		currentTurn = -1;
 		turnTimeUp = false;
 		nextTurnSent = false;
+		nextPCs.clear();
 		
 		new Thread(this).start();
 		
@@ -151,7 +152,7 @@ public class GameData implements Runnable
     	{
     		Player player = itr.next();
     		
-    		if(player.isLocalPlayer())
+    		if(player.isLocalPlayer() && !(player instanceof ComputerPlayer))
     		{
     			return player;
     		}


### PR DESCRIPTION
1. The game will show you a certain computer player's perspective if it's computer's turn in the first turn
2. (Critical)Local player will be regarded as a computer player somehow because the nextPCs haven't been initialized when they join into a new room